### PR TITLE
chore: Allow test namespace to be auto deleted

### DIFF
--- a/clusterloader2/config.yaml
+++ b/clusterloader2/config.yaml
@@ -1,0 +1,51 @@
+name: test
+
+namespace:
+  number: 1
+
+tuningSets:
+- name: Uniform1qps
+  qpsLoad:
+    qps: 1
+
+steps:
+- name: Start measurements
+  measurements:
+  - Identifier: PodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: group = test-pod
+      threshold: 20s
+  - Identifier: WaitForControlledPodsRunning
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: start
+      apiVersion: apps/v1
+      kind: Deployment
+      labelSelector: group = test-deployment
+      operationTimeout: 120s
+- name: Create deployment
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: Uniform1qps
+    objectBundle:
+    - basename: test-deployment
+      objectTemplatePath: "deployment.yaml"
+      templateFillMap:
+        Replicas: 10
+- name: Wait for pods to be running
+  measurements:
+  - Identifier: WaitForControlledPodsRunning
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+- name: Measure pod startup latency
+  measurements:
+  - Identifier: PodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather

--- a/clusterloader2/deployment.yaml
+++ b/clusterloader2/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: test-deployment
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      group: test-pod
+  template:
+    metadata:
+      labels:
+        group: test-pod
+    spec:
+      containers:
+      - image: registry.k8s.io/pause:3.9
+        name: {{.Name}}

--- a/clusterloader2/pkg/framework/client/objects.go
+++ b/clusterloader2/pkg/framework/client/objects.go
@@ -203,7 +203,7 @@ func ListNodesWithOptions(c clientset.Interface, listOpts metav1.ListOptions) ([
 // CreateNamespace creates a single namespace with given name.
 func CreateNamespace(c clientset.Interface, namespace string) error {
 	createFunc := func() error {
-		_, err := c.CoreV1().Namespaces().Create(context.TODO(), &apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+		_, err := c.CoreV1().Namespaces().Create(context.TODO(), &apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: map[string]string{"policy.newrelic.com/termination-protection": "false"}}}, metav1.CreateOptions{})
 		return err
 	}
 	return RetryWithExponentialBackOff(RetryFunction(createFunc, Allow(apierrs.IsAlreadyExists)))


### PR DESCRIPTION
We have a webhook that blocks namespace deletions, which is preventing auto-deletion between tests and increasing manual effort. This commit resolves the issue by adding a label to the namespace during creation that bypasses the webhook.